### PR TITLE
SaiProxy extended functionality

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/dapphub/ds-test
 [submodule "lib/sai"]
 	path = lib/sai
-	url = git@github.com:makerdao/sai
+	url = https://github.com/makerdao/sai
 [submodule "lib/ds-proxy"]
 	path = lib/ds-proxy
 	url = https://github.com/dapphub/ds-proxy
@@ -12,4 +12,4 @@
 	url = https://github.com/dapphub/ds-math
 [submodule "lib/maker-otc"]
 	path = lib/maker-otc
-	url = https://github.com/makerdao/maker-otc.git
+	url = https://github.com/makerdao/maker-otc

--- a/src/SaiProxyCreateAndExecute.sol
+++ b/src/SaiProxyCreateAndExecute.sol
@@ -2,13 +2,13 @@ pragma solidity ^0.4.23;
 
 import "./SaiProxy.sol";
 
-contract ProxyFactoryInterface {
+contract ProxyRegistryInterface {
     function build(address) public returns (address);
 }
 
 contract SaiProxyCreateAndExecute is SaiProxy {
-    function createLockAndDraw(address factory_, address tub_, uint wad) public payable returns (address proxy, bytes32 cup) {
-        proxy = ProxyFactoryInterface(factory_).build(msg.sender);
+    function createLockAndDraw(address registry_, address tub_, uint wad) public payable returns (address proxy, bytes32 cup) {
+        proxy = ProxyRegistryInterface(registry_).build(msg.sender);
         cup = open(tub_);
         lockAndDraw(tub_, cup, wad);
         TubInterface(tub_).give(cup, proxy);

--- a/src/SaiProxyCreateAndExecute.sol
+++ b/src/SaiProxyCreateAndExecute.sol
@@ -7,7 +7,7 @@ contract ProxyRegistryInterface {
 }
 
 contract SaiProxyCreateAndExecute is SaiProxy {
-    function createLockAndDraw(address registry_, address tub_, uint wad) public payable returns (address proxy, bytes32 cup) {
+    function createOpenLockAndDraw(address registry_, address tub_, uint wad) public payable returns (address proxy, bytes32 cup) {
         proxy = ProxyRegistryInterface(registry_).build(msg.sender);
         cup = open(tub_);
         lockAndDraw(tub_, cup, wad);

--- a/src/SaiProxyCreateAndExecute.sol
+++ b/src/SaiProxyCreateAndExecute.sol
@@ -6,7 +6,7 @@ contract ProxyFactoryInterface {
     function build(address) public returns (address);
 }
 
-contract ProxyCreationAndExecute is SaiProxy {
+contract SaiProxyCreateAndExecute is SaiProxy {
     function createLockAndDraw(address factory_, address tub_, uint wad) public payable returns (address proxy, bytes32 cup) {
         proxy = ProxyFactoryInterface(factory_).build(msg.sender);
         cup = open(tub_);

--- a/src/SaiProxyCreateAndExecute.sol
+++ b/src/SaiProxyCreateAndExecute.sol
@@ -7,6 +7,23 @@ contract ProxyRegistryInterface {
 }
 
 contract SaiProxyCreateAndExecute is SaiProxy {
+
+    // Create a DSProxy instance and open a cup
+    function createAndOpen(address registry_, address tub_) public returns (address proxy, bytes32 cup) {
+        proxy = ProxyRegistryInterface(registry_).build(msg.sender);
+        cup = open(tub_);
+        TubInterface(tub_).give(cup, proxy);
+    }
+
+    // Create a DSProxy instance, open a cup, and lock collateral
+    function createOpenAndLock(address registry_, address tub_) public payable returns (address proxy, bytes32 cup) {
+        proxy = ProxyRegistryInterface(registry_).build(msg.sender);
+        cup = open(tub_);
+        lock(tub_, cup);
+        TubInterface(tub_).give(cup, proxy);
+    }
+
+    // Create a DSProxy instance, open a cup, lock collateral, and draw DAI
     function createOpenLockAndDraw(address registry_, address tub_, uint wad) public payable returns (address proxy, bytes32 cup) {
         proxy = ProxyRegistryInterface(registry_).build(msg.sender);
         cup = open(tub_);

--- a/src/SaiProxyCreateAndExecute.t.sol
+++ b/src/SaiProxyCreateAndExecute.t.sol
@@ -15,7 +15,7 @@ contract SaiProxyCreateAndExecuteTest is SaiProxyTest {
     function testCreateLockAndDraw() public {
         uint initialBalance = address(this).balance;
         address newProxy;
-        (newProxy,) = creator.createLockAndDraw.value(10 ether)(factory, tub, 5 ether);
+        (newProxy,) = creator.createOpenLockAndDraw.value(10 ether)(factory, tub, 5 ether);
         assertEq(initialBalance - 10 ether, address(this).balance);
         assertEq(sai.balanceOf(this), 5 ether);
         assertEq(DSProxy(newProxy).owner(), this);

--- a/src/SaiProxyCreateAndExecute.t.sol
+++ b/src/SaiProxyCreateAndExecute.t.sol
@@ -1,14 +1,14 @@
 pragma solidity ^0.4.23;
 
 import "./SaiProxy.t.sol";
-import "./ProxyCreationAndExecute.sol";
+import "./SaiProxyCreateAndExecute.sol";
 
-contract ProxyCreationAndExecuteTest is SaiProxyTest {
-    ProxyCreationAndExecute creator;
+contract SaiProxyCreateAndExecuteTest is SaiProxyTest {
+    SaiProxyCreateAndExecute creator;
 
     function setUp() public {
         super.setUp();
-        creator = new ProxyCreationAndExecute();
+        creator = new SaiProxyCreateAndExecute();
         log_named_address('factory', factory);
     }
 


### PR DESCRIPTION
- Renamed ProxyCreationAndExecute to SaiProxyCreateAndExecute
- Use ProxyRegistryInterface instead of ProxyFactoryInterface
- Rename factory_ method parameter to registry_
- Add createAndOpen() method that: creates a DSProxy instance and opens a cup
- Add createOpenAndLock() method that: creates a DSProxy instance, opens a cup, and locks collateral
- Rename createLockAndDraw() to createOpenLockAndDraw()